### PR TITLE
WIP: Add server_stats class for basic gameplay/session logging

### DIFF
--- a/apps/server/main.cpp
+++ b/apps/server/main.cpp
@@ -153,6 +153,7 @@ int main(int argc, char* argv[])
 
           slice_duration -= update_ms;
           scheduler.update_interval(update_ms);
+          server.m_stats_scheduler.update_interval(update_ms);
         }
 
       const clock::time_point end = clock::now();

--- a/modules/bim/server/CMakeLists.txt
+++ b/modules/bim/server/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(bim_server
   main/src/bim/server/service/matchmaking_service.cpp
   main/src/bim/server/service/named_game_encounter_service.cpp
   main/src/bim/server/service/random_game_encounter_service.cpp
+  main/src/bim/server/service/server_stats.cpp
 )
 
 target_include_directories(bim_server PUBLIC main/include)

--- a/modules/bim/server/main/include/bim/server/server.hpp
+++ b/modules/bim/server/main/include/bim/server/server.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 #pragma once
 
+#include "bim/server/service/server_stats.hpp"
 #include <bim/server/service/authentication_service.hpp>
 #include <bim/server/service/game_service.hpp>
 #include <bim/server/service/lobby_service.hpp>
@@ -16,12 +17,14 @@ namespace bim::server
   {
   public:
     explicit server(const config& config);
+    iscool::schedule::manual_scheduler m_stats_scheduler;
 
   private:
     void dispatch(const iscool::net::endpoint& endpoint,
                   const iscool::net::message& message);
 
   private:
+    server_stats m_server_stats;
     iscool::net::socket_stream m_socket;
     authentication_service m_authentication_service;
     game_service m_game_service;

--- a/modules/bim/server/main/include/bim/server/service/server_stats.hpp
+++ b/modules/bim/server/main/include/bim/server/service/server_stats.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include "bits/chrono.h"
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <iscool/schedule/manual_scheduler.hpp>
+#include <mutex>
+
+namespace bim::server
+{
+  using hour_time =
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::hours>;
+
+  using day_time =
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::days>;
+
+  class server_stats
+  {
+  public:
+    explicit server_stats(iscool::schedule::manual_scheduler& scheduler);
+
+    // Session tracking
+    void record_session_connected();
+    void record_session_disconnected();
+
+    // Game tracking
+    void record_game_start(uint8_t player_count);
+    void record_game_end(uint8_t player_count);
+
+  private:
+    // scheduler for data dumps & log rotation
+    iscool::schedule::manual_scheduler& m_scheduler;
+
+    // Logging control
+    void schedule_next_hourly_dump();
+    void schedule_daily_rotation();
+    void rotate_log();
+    void dump_hourly_stats();
+
+    // Tracked Stats counters
+    std::atomic<int> m_active_sessions{ 0 };
+    std::atomic<int> m_players_in_games{ 0 };
+    std::atomic<int> m_current_games{ 0 };
+    std::atomic<int> m_games_this_hour{ 0 };
+
+    // Logging state
+    std::mutex m_log_mutex;
+    std::ofstream m_log_file;
+
+    void write_header();
+    void write_current_stats();
+  };
+}

--- a/modules/bim/server/main/src/bim/server/server.cpp
+++ b/modules/bim/server/main/src/bim/server/server.cpp
@@ -10,9 +10,10 @@
 #include <iscool/net/message/message.hpp>
 
 bim::server::server::server(const config& config)
-  : m_socket(config.port)
-  , m_authentication_service(config, m_socket)
-  , m_game_service(config, m_socket)
+  : m_server_stats(m_stats_scheduler)
+  , m_socket(config.port)
+  , m_authentication_service(config, m_socket, m_server_stats)
+  , m_game_service(config, m_socket, m_server_stats)
   , m_lobby_service(config, m_socket, m_game_service)
 {
   ic_log(iscool::log::nature::info(), "server", "Server is up on port {}.",

--- a/modules/bim/server/main/src/bim/server/service/server_stats.cpp
+++ b/modules/bim/server/main/src/bim/server/service/server_stats.cpp
@@ -1,0 +1,120 @@
+#include <bim/server/service/server_stats.hpp>
+
+namespace bim::server
+{
+  server_stats::server_stats(iscool::schedule::manual_scheduler& schedular)
+    : m_scheduler(schedular)
+  {
+    schedule_next_hourly_dump();
+    schedule_daily_rotation();
+  }
+
+  void server_stats::record_session_connected()
+  {
+    m_active_sessions++;
+  }
+
+  void server_stats::record_session_disconnected()
+  {
+    m_active_sessions--;
+  }
+
+  void server_stats::record_game_start(uint8_t player_count)
+  {
+    m_current_games++;
+    m_players_in_games += player_count;
+    m_games_this_hour++;
+  }
+
+  void server_stats::record_game_end(uint8_t player_count)
+  {
+    m_current_games--;
+    m_players_in_games -= player_count;
+  }
+
+  void server_stats::dump_hourly_stats()
+  {
+    std::lock_guard lock(m_log_mutex);
+    write_current_stats();
+  }
+
+  void server_stats::write_current_stats()
+  {
+    const std::chrono::system_clock::time_point now =
+        std::chrono::system_clock::now();
+
+    m_log_file << std::format("{:%T},", now) << m_active_sessions.load() << ","
+               << m_players_in_games.load() << "," << m_current_games.load()
+               << "," << m_games_this_hour.load() << "\n";
+
+    // Reset hourly counter
+    m_games_this_hour = 0;
+  }
+
+  void server_stats::write_header()
+  {
+    m_log_file << "Time, active_sessions , players_in_game, current_games, "
+                  "games_this_hour"
+               << "\n";
+  }
+
+  void server_stats::schedule_next_hourly_dump()
+  {
+    const std::chrono::system_clock::time_point now =
+        std::chrono::system_clock::now();
+    hour_time current_hour = std::chrono::floor<std::chrono::hours>(now);
+    hour_time next_hour = current_hour + std::chrono::hours(1);
+
+    std::chrono::system_clock::duration delay = next_hour - now;
+
+    // Convert delay to nanoseconds (as expected by the scheduler)
+    const std::chrono::nanoseconds delay_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(delay);
+
+    // Schedule the next hourly dump
+    m_scheduler.get_delayed_call_delegate()(
+        [this]()
+        {
+          dump_hourly_stats();
+          schedule_next_hourly_dump(); // Schedule the next data dump
+        },
+        delay_ns);
+  }
+
+  void server_stats::schedule_daily_rotation()
+  {
+    const std::chrono::system_clock::time_point now =
+        std::chrono::system_clock::now();
+    day_time current_day = std::chrono::floor<std::chrono::days>(now);
+    day_time next_day = current_day + std::chrono::days(1);
+
+    std::chrono::system_clock::duration delay = next_day - now;
+    const std::chrono::nanoseconds delay_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(delay);
+
+    m_scheduler.get_delayed_call_delegate()(
+        [this]()
+        {
+          rotate_log();
+          schedule_daily_rotation(); // Schedule the next rotation
+        },
+        delay_ns);
+  }
+
+  void server_stats::rotate_log()
+  {
+    std::lock_guard lock(m_log_mutex);
+    if (m_log_file.is_open())
+      m_log_file.close();
+
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::ostringstream filename;
+    filename << "stats_" << std::put_time(std::localtime(&t), "%Y-%m-%d")
+             << ".log";
+
+    m_log_file.open(filename.str(), std::ios::out | std::ios::app);
+    write_header();
+  }
+
+}


### PR DESCRIPTION
# NB work in progress

## So far

NB: Work in progress — I wanted to check if this is aligned with your expectations before continuing with the full refactor.


- Added server_stats class
- Instatiated in servers constructor
- Uses `iscool::schedule::manual_sheduler` to
- - dump data hour
- - update logfile daily
- Simple csv logs for easy inspection/processing
- e.g log file  2025-05-07.log
- eg log format

HH:MM:SS | active_sessions | players_in_games | current_games | games_this_hour
00:00:00 | 1 | 2 | 3 | 4
01:00:00 | 1               | 2                | 3             | 4
...
23:00:00 | 1               | 2                | 3             | 4


## Plan

- Pass a reference to `server_stats` into `authentication_service` and `game_service` to allow them to update counters directly.
- Example: `game_service::new_game()` calls `record_game_start()` to increment the relevant stats.
- Integrate with existing tests where possible to verify counters are updated correctly

## Question

- Is this what you had in mind?
- Before I refactor game_service and authentication_service to accept a server_stats reference, I wanted to confirm the direction is sound since it touches several parts of the server.